### PR TITLE
Mynewt 1.6 compatiblity

### DIFF
--- a/test/src/ht16k33_test_priv.h
+++ b/test/src/ht16k33_test_priv.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-int ht16k33_test_suite(void);
+TEST_SUITE_DECL(ht16k33_test_suite);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Mynewt `testutil` library is going through some changes.  I was using the unit test package in this repo to verify that the Mynewt changes are backwards incompatible.  In the process, I noticed a few other things that will break with the next release of Mynewt (1.6).